### PR TITLE
Add CI workflow to build project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y libncurses-dev
+      - name: Build
+        run: make


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to build ghstatus using `make`
- Install `libncurses-dev` dependency before building

## Testing
- `make`
- `./ghstatus`


------
https://chatgpt.com/codex/tasks/task_e_68a1f86eeeb88328b02b6ff1105bc82c