### PR TITLE
Add web-based GitHub status monitor

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,32 @@
+name: Deploy to GitHub Pages
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-
+# GitHub Actions Build Monitor
 
 https://github.com/user-attachments/assets/879a2730-b4ae-4862-93a5-d5c3f6ed00ba
 
+## Web version
+
+A JavaScript implementation (`index.html` and `ghstatus.js`) fetches public
+repositories for the provided GitHub usernames and displays the latest workflow
+run status using emoji icons. The site is automatically deployed to GitHub
+Pages via the included workflow.

--- a/ghstatus.js
+++ b/ghstatus.js
@@ -1,0 +1,62 @@
+const statusIcons = {
+  success: "✅",
+  failure: "❌",
+  cancelled: "🛑",
+  skipped: "⏭️",
+  timed_out: "⌛",
+  action_required: "⛔",
+  neutral: "⭕",
+  stale: "🥖",
+  in_progress: "🔁",
+  queued: "📋",
+  loading: "🌀",
+  default: "➖",
+};
+
+function iconFor(status) {
+  for (const key in statusIcons) {
+    if (status.includes(key)) return statusIcons[key];
+  }
+  return statusIcons.default;
+}
+
+async function fetchRepos(user) {
+  const resp = await fetch(
+    `https://api.github.com/users/${user}/repos?per_page=100&type=public`
+  );
+  if (!resp.ok) return [];
+  const data = await resp.json();
+  return data.map((r) => r.full_name);
+}
+
+async function fetchStatus(repo) {
+  const resp = await fetch(
+    `https://api.github.com/repos/${repo}/actions/runs?per_page=1`
+  );
+  if (!resp.ok) return "unknown";
+  const data = await resp.json();
+  if (data.workflow_runs.length === 0) return "no_runs";
+  const run = data.workflow_runs[0];
+  return `${run.status} ${run.conclusion}`;
+}
+
+async function load() {
+  const input = document.getElementById("users");
+  const users = input.value.split(/\s+/).filter(Boolean);
+  const list = document.getElementById("results");
+  list.innerHTML = "";
+
+  const repos = (await Promise.all(users.map(fetchRepos))).flat();
+
+  for (const repo of repos) {
+    const li = document.createElement("li");
+    li.textContent = `${repo} - loading`;
+    list.appendChild(li);
+    fetchStatus(repo).then((status) => {
+      const icon = iconFor(status);
+      li.textContent = `${icon} ${repo} - ${status}`;
+    });
+  }
+}
+
+document.getElementById("load").addEventListener("click", load);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>GitHub Actions Status</title>
+</head>
+<body>
+  <h1>GitHub Actions Status</h1>
+  <p>Enter GitHub usernames separated by spaces:</p>
+  <input id="users" type="text" placeholder="user1 user2" />
+  <button id="load">Load</button>
+  <ul id="results"></ul>
+  <script src="ghstatus.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add simple web interface (index.html/ghstatus.js) to fetch latest workflow status for specified GitHub users.
- Document web version and enable automatic GitHub Pages deployment.
- Set up GitHub Actions workflow to publish site to GitHub Pages.

## Testing
- `pre-commit run --files index.html ghstatus.js README.md .github/workflows/pages.yml`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68a1fad202ec8328b3ba567d8b77bc2a