### PR TITLE
Enable Enter key to trigger GitHub status loading

### DIFF
--- a/ghstatus.js
+++ b/ghstatus.js
@@ -60,3 +60,10 @@ async function load() {
 }
 
 document.getElementById("load").addEventListener("click", load);
+document
+  .getElementById("users")
+  .addEventListener("keydown", (event) => {
+    if (event.key === "Enter") {
+      load();
+    }
+  });


### PR DESCRIPTION
## Summary
- add keydown listener to `users` input to load statuses on Enter

## Testing
- `node --check ghstatus.js`
- `make ghstatus`


------
https://chatgpt.com/codex/tasks/task_e_68a20a633570832898355899512a5cfa