### PR TITLE
Handle fetch errors

### DIFF
--- a/ghstatus.js
+++ b/ghstatus.js
@@ -10,6 +10,7 @@ const statusIcons = {
   in_progress: "🔁",
   queued: "📋",
   loading: "🌀",
+  error: "⚠️",
   default: "➖",
 };
 
@@ -21,23 +22,33 @@ function iconFor(status) {
 }
 
 async function fetchRepos(user) {
-  const resp = await fetch(
-    `https://api.github.com/users/${user}/repos?per_page=100&type=public`,
-  );
-  if (!resp.ok) return [];
-  const data = await resp.json();
-  return data.map((r) => r.full_name);
+  try {
+    const resp = await fetch(
+      `https://api.github.com/users/${user}/repos?per_page=100&type=public`,
+    );
+    if (!resp.ok) return [];
+    const data = await resp.json();
+    return data.map((r) => r.full_name);
+  } catch (err) {
+    console.error("Failed to fetch repos:", err);
+    return [];
+  }
 }
 
 async function fetchStatus(repo) {
-  const resp = await fetch(
-    `https://api.github.com/repos/${repo}/actions/runs?per_page=1`,
-  );
-  if (!resp.ok) return "unknown";
-  const data = await resp.json();
-  if (data.workflow_runs.length === 0) return "no_runs";
-  const run = data.workflow_runs[0];
-  return `${run.status} ${run.conclusion}`;
+  try {
+    const resp = await fetch(
+      `https://api.github.com/repos/${repo}/actions/runs?per_page=1`,
+    );
+    if (!resp.ok) return "error";
+    const data = await resp.json();
+    if (data.workflow_runs.length === 0) return "no_runs";
+    const run = data.workflow_runs[0];
+    return `${run.status} ${run.conclusion}`;
+  } catch (err) {
+    console.error("Failed to fetch status:", err);
+    return "error";
+  }
 }
 
 async function load() {
@@ -48,11 +59,21 @@ async function load() {
 
   const repos = (await Promise.all(users.map(fetchRepos))).flat();
 
+  if (repos.length === 0) {
+    list.innerHTML =
+      "<li>No repositories found or error fetching repositories</li>";
+    return;
+  }
+
   for (const repo of repos) {
     const li = document.createElement("li");
     li.textContent = `${repo} - loading`;
     list.appendChild(li);
     fetchStatus(repo).then((status) => {
+      if (status === "error") {
+        li.textContent = `⚠️ ${repo} - error fetching status`;
+        return;
+      }
       const icon = iconFor(status);
       li.textContent = `${icon} ${repo} - ${status}`;
     });


### PR DESCRIPTION
## Summary
- handle failures in fetchRepos and fetchStatus with try/catch and fallbacks
- show warnings when repository or status retrieval fails

## Testing
- `pre-commit run --files ghstatus.js`

------
https://chatgpt.com/codex/tasks/task_e_68a20a5708d8832897c4685f67610a34