### PR TITLE
Handle paginated repository results

### DIFF
--- a/ghstatus.js
+++ b/ghstatus.js
@@ -21,12 +21,17 @@ function iconFor(status) {
 }
 
 async function fetchRepos(user) {
-  const resp = await fetch(
-    `https://api.github.com/users/${user}/repos?per_page=100&type=public`,
-  );
-  if (!resp.ok) return [];
-  const data = await resp.json();
-  return data.map((r) => r.full_name);
+  const repos = [];
+  for (let page = 1; ; page += 1) {
+    const resp = await fetch(
+      `https://api.github.com/users/${user}/repos?per_page=100&type=public&page=${page}`,
+    );
+    if (!resp.ok) break;
+    const data = await resp.json();
+    repos.push(...data);
+    if (data.length < 100) break;
+  }
+  return repos.map((r) => r.full_name);
 }
 
 async function fetchStatus(repo) {


### PR DESCRIPTION
## Summary
- Iterate through GitHub repository pages until fewer than 100 results
- Aggregate repositories from all pages

## Testing
- `pre-commit run --files ghstatus.js`


------
https://chatgpt.com/codex/tasks/task_e_68a20a5010808328b5ab578cd65cc9ff