### PR TITLE
Handle repository fetch errors separately

### DIFF
--- a/ghstatus.js
+++ b/ghstatus.js
@@ -43,8 +43,7 @@ async function fetchRepos(user) {
     }
   }
   const repoNames = repos.map((r) => r.full_name);
-  if (errorOccurred) repoNames.error = true;
-  return repoNames;
+  return { names: repoNames, error: errorOccurred };
 }
 
 async function fetchStatus(repo) {
@@ -71,7 +70,7 @@ async function load() {
 
   const repoLists = await Promise.all(users.map(fetchRepos));
   const repoFetchFailed = repoLists.some((r) => r.error);
-  const repos = repoLists.flat();
+  const repos = repoLists.flatMap((r) => r.names);
 
   if (repoFetchFailed) {
     list.innerHTML = "<li>⚠️ Error fetching repositories</li>";


### PR DESCRIPTION
## Summary
- Return both repository names and error status from `fetchRepos`.
- Update `load` to aggregate repo names and detect fetch failures.

## Testing
- `node --check ghstatus.js`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68a2497ee10c8328b0afe67536f6376a