### PR TITLE
Guarantee STATUS string null termination

### DIFF
--- a/ghstatus.c
+++ b/ghstatus.c
@@ -337,6 +337,7 @@ int main(int argc, char **argv) {
           buf[n] = '\0';
           buf[strcspn(buf, "\n")] = 0;
           strncpy(STATUS[i], buf, sizeof(STATUS[i]) - 1);
+          STATUS[i][sizeof(STATUS[i]) - 1] = '\0';
         } else if (n == 0) {
           close(pipes[i][0]);
           waitpid(fetch_pids[i], NULL, 0);


### PR DESCRIPTION
## Summary
- ensure copied status strings are explicitly null-terminated

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68a249654b3483289195eab9ef73aad4