### PR TITLE
Add SIGINT handler to cleanup curses on exit

### DIFF
--- a/ghstatus.c
+++ b/ghstatus.c
@@ -33,6 +33,9 @@ SortMode sort_mode = SORT_DEFAULT;
 int ORIGINAL_INDEX[MAX_REPOS]; // for restoring original order
 int order[MAX_REPOS];          // active display order
 
+int pipes[MAX_REPOS][2];
+pid_t fetch_pids[MAX_REPOS];
+
 // button hover state
 int hover_x = -1, hover_y = -1;
 
@@ -194,6 +197,13 @@ void cleanup(int pipes[][2], pid_t pids[]) {
   }
 }
 
+void handle_sigint(int signo) {
+  (void)signo;
+  cleanup(pipes, fetch_pids);
+  endwin();
+  exit(0);
+}
+
 long long now_ms(void) {
   struct timespec ts;
   clock_gettime(CLOCK_MONOTONIC, &ts);
@@ -244,8 +254,6 @@ int main(int argc, char **argv) {
     order[i] = i;
   }
 
-  int pipes[MAX_REPOS][2];
-  pid_t fetch_pids[MAX_REPOS];
   for (int i = 0; i < MAX_REPOS; i++) {
     pipes[i][0] = pipes[i][1] = -1;
     fetch_pids[i] = -1;
@@ -280,6 +288,9 @@ int main(int argc, char **argv) {
   init_pair(5, COLOR_BLUE, COLOR_GREEN);   // skipped
   init_pair(6, COLOR_RED, COLOR_YELLOW);   // action_required
   init_pair(7, COLOR_WHITE, COLOR_BLUE);   // in_progress
+
+  signal(SIGINT, handle_sigint);
+  signal(SIGTERM, handle_sigint);
 
   int ch;
   time_t last_poll = time(NULL);


### PR DESCRIPTION
## Summary
- Allow early termination by handling SIGINT/SIGTERM, cleaning up resources and exiting gracefully.
- Expose pipes and fetch PID arrays globally so the signal handler can access them.

## Testing
- `make clean && make`


------
https://chatgpt.com/codex/tasks/task_e_68a249740e608328b18d81f4db73a891