### PR TITLE
Fix syntax error in ghstatus.js

### DIFF
--- a/ghstatus.js
+++ b/ghstatus.js
@@ -51,9 +51,10 @@ async function fetchRepos(user) {
       console.error("Failed to fetch repos:", err);
       error = "error";
       break;
-   }
+    }
+  }
   const repoNames = repos.map((r) => r.full_name);
-  return { names: repoNames, error: errorOccurred };
+  return { names: repoNames, error };
 }
 
 async function fetchStatus(repo) {


### PR DESCRIPTION
## Summary
- close missing loop in `fetchRepos`
- return correct error variable

## Testing
- `node --check ghstatus.js`


------
https://chatgpt.com/codex/tasks/task_e_68a24c7eb3408328b2ce216e08ebb471