### PR TITLE
ci: run pre-commit in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y libncurses-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libncurses-dev
+          pip install pre-commit
+      - name: Run pre-commit
+        run: pre-commit run --show-diff-on-failure --all-files
       - name: Build
         run: make

--- a/ghstatus.c
+++ b/ghstatus.c
@@ -9,18 +9,18 @@
 #include <fcntl.h>
 #include <locale.h>
 #include <ncursesw/ncurses.h>
+#include <signal.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/select.h>
-#include <signal.h>
 #include <sys/wait.h>
 #include <time.h>
 #include <unistd.h>
 #include <wchar.h>
 
 #define MAX_REPOS 2048
-#define POLL_INTERVAL_S 300  // seconds between full refresh
-#define SPIN_INTERVAL_MS 125 // ms between spinner frame changes
+#define POLL_INTERVAL_S 300       // seconds between full refresh
+#define SPIN_INTERVAL_MS 125      // ms between spinner frame changes
 #define MAX_CONCURRENT_FETCHES 32 // max number of simultaneous fetches
 
 char *REPOS[MAX_REPOS];


### PR DESCRIPTION
## Summary
- install pre-commit during CI runs
- run pre-commit on all files before building
- format `ghstatus.c` to satisfy clang-format

## Testing
- `pre-commit run --show-diff-on-failure --all-files`
- `make clean && make`


------
https://chatgpt.com/codex/tasks/task_e_68a24eeb547c8328bb1d460cd2da80ae