### PR TITLE
Allow configuring poll interval and concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,15 @@ make
 ### Usage
 
 Invoke the program with a GitHub username to show workflow status for that
-user's repositories:
+user's repositories. Optional flags allow customization of refresh timing and
+concurrency:
 
 ```sh
-./ghstatus <user>
+./ghstatus [-p seconds] [-c count] <user> [user2 ...]
 ```
+
+`-p` sets the refresh interval in seconds (default 300) and `-c` limits the
+number of simultaneous fetches (default 32).
 
 The tool relies on the GitHub CLI for API requests. To access private
 repositories the CLI must be authenticated (`gh auth login`) and the account


### PR DESCRIPTION
## Summary
- parse optional `-p` (poll interval) and `-c` (concurrency) flags
- apply parsed values when scheduling refreshes and spawning fetches
- document new flags in README and usage text

## Testing
- `pre-commit run --files ghstatus.c README.md`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68a24f15e79083288d5400e1a1053935