### PR TITLE
Handle repository fetch failures

### DIFF
--- a/ghstatus.js
+++ b/ghstatus.js
@@ -87,7 +87,14 @@ async function load() {
   const list = document.getElementById("results");
   list.innerHTML = "";
 
-  const repoLists = await Promise.all(users.map(fetchRepos));
+  let repoLists;
+  try {
+    repoLists = await Promise.all(users.map(fetchRepos));
+  } catch (err) {
+    console.error("Failed to load repositories:", err);
+    list.innerHTML = "<li>⚠️ Error loading repositories</li>";
+    return;
+  }
 
   const rateLimited = repoLists.some((r) => r.error === "rate_limit");
   const repoFetchFailed = repoLists.some(


### PR DESCRIPTION
## Summary
- guard repository fetch in `load` with try/catch to show an error instead of throwing when requests fail

## Testing
- `pre-commit run --files ghstatus.js index.html README.md`

------
https://chatgpt.com/codex/tasks/task_e_68a24f07181083289d604452bfe4e8bb