### PR TITLE
Handle missing repoResults variable in JS loader

### DIFF
--- a/ghstatus.js
+++ b/ghstatus.js
@@ -87,9 +87,9 @@ async function load() {
   const list = document.getElementById("results");
   list.innerHTML = "";
 
-  let repoLists;
+  let repoResults;
   try {
-    repoLists = await Promise.all(users.map(fetchRepos));
+    repoResults = await Promise.allSettled(users.map(fetchRepos));
   } catch (err) {
     console.error("Failed to load repositories:", err);
     list.innerHTML = "<li>⚠️ Error loading repositories</li>";
@@ -106,6 +106,9 @@ async function load() {
       (r.status === "fulfilled" &&
         r.value.error &&
         r.value.error !== "rate_limit"),
+  );
+  const repoLists = repoResults.map((r) =>
+    r.status === "fulfilled" ? r.value : { names: [], error: "error" },
   );
 
   if (rateLimited) {


### PR DESCRIPTION
## Summary
- fix undefined `repoResults` reference by using `Promise.allSettled`
- gracefully handle repository fetch failures and rate limit checks

## Testing
- `pre-commit run --files ghstatus.js`

------
https://chatgpt.com/codex/tasks/task_e_68a2527b5c248328a24fea71a13e6dab