### PR TITLE
Handle memory allocation failure when loading repos

### DIFF
--- a/ghstatus.c
+++ b/ghstatus.c
@@ -88,7 +88,16 @@ void load_repos(const char *user) {
   char line[256];
   while (fgets(line, sizeof(line), fp) && NUM_REPOS < MAX_REPOS) {
     line[strcspn(line, "\n")] = 0;
-    REPOS[NUM_REPOS++] = strdup(line);
+    char *copy = strdup(line);
+    if (!copy) {
+      // allocation failed; roll back any repos added in this call
+      fprintf(stderr, "Failed to allocate repo name\n");
+      while (NUM_REPOS > old_num) {
+        free(REPOS[--NUM_REPOS]);
+      }
+      break; // stop reading further repositories
+    }
+    REPOS[NUM_REPOS++] = copy;
   }
   fclose(fp);
 


### PR DESCRIPTION
## Summary
- Check the result of `strdup` when loading repository names
- On allocation failure, log an error, roll back partial additions, and stop reading

## Testing
- `make clean && make`


------
https://chatgpt.com/codex/tasks/task_e_68a254d1d9a88328930092376b8e0ecb