### PR TITLE
Warn on missing GitHub usernames

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ repositories for the provided GitHub usernames and displays the latest workflow
 run status using emoji icons. The site is automatically deployed to GitHub
 Pages via the included workflow.
 
+If a username is invalid, the page lists a warning like `⚠️ Username octocat not found`.
+
 ## Terminal version
 
 The `ghstatus.c` program renders the build monitor in a terminal using


### PR DESCRIPTION
## Summary
- Return a `not_found` error when GitHub user lookups return 404
- Display a warning for usernames that do not exist
- Document the new warning behavior in the README

## Testing
- `node -c ghstatus.js`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68a254c00dc0832895e737ad1ed5a748