### PR TITLE
Add unit tests for status mapping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,18 @@ CC ?= gcc
 CFLAGS ?= -Wall -Wextra
 LDFLAGS ?= -lncursesw
 
-.PHONY: all clean
+.PHONY: all clean test
 
 all: ghstatus
 
 ghstatus: ghstatus.c
 	$(CC) $(CFLAGS) -o $@ $< $(LDFLAGS)
 
+test: test_status
+	./test_status
+
+test_status: test_status.c ghstatus.c
+	$(CC) $(CFLAGS) -o $@ test_status.c $(LDFLAGS)
+
 clean:
-	rm -f ghstatus
+	rm -f ghstatus test_status

--- a/test_status.c
+++ b/test_status.c
@@ -1,0 +1,18 @@
+#include <assert.h>
+#include <locale.h>
+#include <wchar.h>
+#define main ghstatus_main
+#include "ghstatus.c"
+#undef main
+
+int main(void) {
+    setlocale(LC_ALL, "");
+    assert(wcscmp(status_icon("success"), L"✅") == 0);
+    assert(wcscmp(status_icon("failure"), L"❌") == 0);
+    assert(wcscmp(status_icon("unknown"), L"➖") == 0);
+
+    assert(status_color("success") == 1);
+    assert(status_color("failure") == 2);
+    assert(status_color("unknown") == 3);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add C unit test verifying icon and color mapping
- wire up a `make test` target to build and run the new test

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a256488b648328a764b719cd28c3be