### PR TITLE
Add APL implementation of build monitor

### DIFF
--- a/ghstatus.apl
+++ b/ghstatus.apl
@@ -1,0 +1,42 @@
+⍝ GitHub Actions Build Monitor in APL
+⍝ Uses GitHub CLI to fetch latest workflow run for repositories.
+⍝ Usage: dyalogscript ghstatus.apl user1 user2 ...
+
+⎕IO←0
+
+GetArgs←{2⊃⎕NQ '.' 'GetCommandLineArgs'}
+
+RepoList←{
+    user←⍵
+    data←⎕JSON ⎕CMD 'gh repo list ',user,' --limit 100 --json nameWithOwner'
+    data['nameWithOwner']
+}
+
+RunStatus←{
+    repo←⍵
+    runs←⎕JSON ⎕CMD 'gh run list ',repo,' --limit 1 --json conclusion status'
+    0=≢runs:'⚪'
+    run←runs[0]
+    stat←run['status']
+    conc←run['conclusion']
+    stat≡'queued':'⏳'
+    stat≡'in_progress':'🏃'
+    conc≡'success':'✅'
+    conc≡'failure':'❌'
+    conc≡'cancelled':'🚫'
+    '❓'
+}
+
+ShowRepo←{
+    repo←⍵
+    emoji←RunStatus repo
+    ⎕←emoji,' ',repo
+}
+
+main←{
+    users←GetArgs
+    repos←∊RepoList¨users
+    ShowRepo¨repos
+}
+
+main ⍬


### PR DESCRIPTION
## Summary
- add an APL script `ghstatus.apl` that uses GitHub CLI to show latest workflow status for repositories

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a73d9306308328b5f69d8efabfff6f