### PR TITLE
Add Perl-based GitHub status monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,23 @@ The tool relies on the GitHub CLI for API requests. To access private
 repositories the CLI must be authenticated (`gh auth login`) and the account
 must have permission to view those repositories. Without authentication or
 appropriate access, private repository information cannot be displayed.
+
+## Perl version
+
+The `ghstatus.pl` script provides a simple command-line monitor written in
+Perl. It queries repositories for the specified GitHub usernames and prints the
+latest workflow run status using emoji icons.
+
+### Dependencies
+
+- Perl 5
+- [GitHub CLI](https://cli.github.com/)
+
+### Usage
+
+```sh
+./ghstatus.pl <user> [user2 ...]
+```
+
+Flags `-p` and `-c` mirror the terminal version's options. The script refreshes
+every `-p` seconds (default 300) until interrupted.

--- a/ghstatus.pl
+++ b/ghstatus.pl
@@ -1,0 +1,61 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use utf8;
+use Getopt::Long;
+use JSON::PP;
+
+binmode STDOUT, ":utf8";
+
+my $period = 300;
+my $concurrency = 32; # unused, but kept for CLI compatibility
+GetOptions(
+    'p=i' => \$period,
+    'c=i' => \$concurrency,
+) or usage();
+
+my @users = @ARGV;
+usage() unless @users;
+
+sub usage {
+    die "Usage: $0 [-p seconds] [-c count] <user> [user2 ...]\n";
+}
+
+my %icons = (
+    success => "✅",
+    failure => "❌",
+    cancelled => "⏹️",
+    timed_out => "⏱️",
+    action_required => "⚠️",
+    unknown => "➖",
+);
+
+sub fetch_repos {
+    my ($user) = @_;
+    my $json = `gh repo list $user --limit 100 --json name`;
+    die "failed to list repos for $user\n" if $? != 0;
+    return decode_json($json);
+}
+
+sub fetch_status {
+    my ($user, $repo) = @_;
+    my $json = `gh api repos/$user/$repo/actions/runs?per_page=1`;
+    return 'unknown' if $? != 0;
+    my $data = decode_json($json);
+    return $data->{workflow_runs}[0]{conclusion} // 'unknown';
+}
+
+while (1) {
+    system('clear');
+    for my $user (@users) {
+        my $repos = fetch_repos($user);
+        for my $repo (@$repos) {
+            my $name = $repo->{name};
+            my $status = fetch_status($user, $name);
+            my $icon = $icons{$status} // $icons{unknown};
+            print "$user/$name $icon $status\n";
+        }
+    }
+    last if $period <= 0;
+    sleep $period;
+}


### PR DESCRIPTION
## Summary
- add `ghstatus.pl` Perl script to query repositories and show workflow statuses with emoji icons
- document Perl version and usage in README

## Testing
- `pre-commit run --files ghstatus.pl README.md`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a73d8f35988328960595a494a47137