### PR TITLE
Add PL/pgSQL version of GitHub Actions monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,19 @@ The tool relies on the GitHub CLI for API requests. To access private
 repositories the CLI must be authenticated (`gh auth login`) and the account
 must have permission to view those repositories. Without authentication or
 appropriate access, private repository information cannot be displayed.
+
+## PL/pgSQL version
+
+The `ghstatus.sql` script defines a PostgreSQL function that retrieves the
+latest GitHub Actions workflow run for repositories owned by the provided
+usernames. It relies on the [`http` extension](https://github.com/pramsey/pgsql-http)
+to query the GitHub API directly from the database.
+
+### Usage
+
+Load the script and call the function with an array of usernames:
+
+```sql
+\i ghstatus.sql
+SELECT * FROM ghstatus_latest_runs(ARRAY['octocat']);
+```

--- a/ghstatus.sql
+++ b/ghstatus.sql
@@ -1,0 +1,42 @@
+-- PL/pgSQL implementation of GitHub Actions Build Monitor
+-- Requires the pgsql-http extension: https://github.com/pramsey/pgsql-http
+
+CREATE EXTENSION IF NOT EXISTS http;
+
+-- Fetch latest workflow runs for each repository owned by the given GitHub usernames.
+-- Returns one row per repository with the workflow conclusion and a link to the run.
+CREATE OR REPLACE FUNCTION ghstatus_latest_runs(usernames text[])
+RETURNS TABLE(
+    username    text,
+    repository  text,
+    status      text,
+    html_url    text
+) LANGUAGE plpgsql AS $$
+DECLARE
+    user_name text;
+    repos jsonb;
+    repo jsonb;
+    run_resp http_response;
+    run jsonb;
+    api_base CONSTANT text := 'https://api.github.com';
+BEGIN
+    FOREACH user_name IN ARRAY usernames LOOP
+        -- list repositories for the user
+        SELECT content::jsonb INTO repos
+        FROM http_get(api_base || '/users/' || user_name || '/repos');
+
+        FOR repo IN SELECT * FROM jsonb_array_elements(repos) LOOP
+            -- fetch the most recent workflow run for the repository
+            SELECT * INTO run_resp
+            FROM http_get(api_base || '/repos/' || repo->>'full_name' || '/actions/runs?per_page=1');
+
+            run := run_resp.content::jsonb -> 'workflow_runs' -> 0;
+            username   := user_name;
+            repository := repo->>'name';
+            status     := COALESCE(run->>'conclusion', run->>'status');
+            html_url   := run->>'html_url';
+            RETURN NEXT;
+        END LOOP;
+    END LOOP;
+END;
+$$;


### PR DESCRIPTION
## Summary
- add `ghstatus_latest_runs` PL/pgSQL function using the `http` extension to fetch latest workflow run data
- document how to load and use the function in PostgreSQL

## Testing
- `pre-commit run --files README.md ghstatus.sql`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68a73dfd2a5c8328ad78cabd519ed29c