### PR TITLE
Add Zig implementation of build monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,26 @@ The tool relies on the GitHub CLI for API requests. To access private
 repositories the CLI must be authenticated (`gh auth login`) and the account
 must have permission to view those repositories. Without authentication or
 appropriate access, private repository information cannot be displayed.
+
+## Zig version
+
+`ghstatus.zig` and `status.zig` provide a lightweight implementation of the
+monitor in [Zig](https://ziglang.org/). It invokes the GitHub CLI to fetch the
+latest workflow status for each repository and prints an emoji icon alongside
+the repository name.
+
+### Build
+
+Compile the executable with Zig:
+
+```sh
+zig build-exe ghstatus.zig
+```
+
+### Test
+
+Unit tests verify the status‑to‑emoji/color mapping:
+
+```sh
+zig test status.zig
+```

--- a/ghstatus.zig
+++ b/ghstatus.zig
@@ -1,0 +1,80 @@
+const std = @import("std");
+const status = @import("status.zig");
+
+fn getRepos(allocator: std.mem.Allocator, user: []const u8) ![][]const u8 {
+    const argv = &[_][]const u8{
+        "gh",     "repo",          "list", user,                "--public", "--limit", "500",
+        "--json", "nameWithOwner", "--jq", ".[].nameWithOwner",
+    };
+    var result = try std.ChildProcess.exec(.{ .allocator = allocator, .argv = argv });
+    defer {
+        allocator.free(result.stdout);
+        allocator.free(result.stderr);
+    }
+
+    var list = std.ArrayList([]const u8).init(allocator);
+    defer list.deinit();
+
+    var it = std.mem.split(u8, result.stdout, "\n");
+    while (it.next()) |line| {
+        if (line.len == 0) continue;
+        try list.append(try allocator.dupe(u8, line));
+    }
+    return list.toOwnedSlice();
+}
+
+fn getRepoStatus(allocator: std.mem.Allocator, repo: []const u8) ![]const u8 {
+    const path = try std.fmt.allocPrint(allocator, "repos/{s}/actions/runs?per_page=1", .{repo});
+    defer allocator.free(path);
+
+    const argv = &[_][]const u8{ "gh", "api", path, "--jq", ".workflow_runs[0].conclusion" };
+    var result = try std.ChildProcess.exec(.{ .allocator = allocator, .argv = argv });
+    defer {
+        allocator.free(result.stdout);
+        allocator.free(result.stderr);
+    }
+
+    const trimmed = std.mem.trimRight(u8, result.stdout, "\n");
+    return allocator.dupe(u8, trimmed);
+}
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer {
+        const leaked = gpa.deinit();
+        std.debug.assert(leaked == .ok);
+    }
+    const allocator = gpa.allocator();
+
+    var args = std.process.args();
+    _ = args.next(); // skip program name
+    const first = args.next() orelse {
+        std.debug.print("usage: ghstatus <user> [user2 ...]\n", .{});
+        return;
+    };
+
+    var users = std.ArrayList([]const u8).init(allocator);
+    defer users.deinit();
+    try users.append(first);
+    while (args.next()) |u| try users.append(u);
+
+    for (users.items) |user| {
+        std.debug.print("User: {s}\n", .{user});
+        const repos = getRepos(allocator, user) catch |e| {
+            std.debug.print("failed to list repos for {s}: {s}\n", .{ user, @errorName(e) });
+            continue;
+        };
+        defer {
+            for (repos) |r| allocator.free(r);
+            allocator.free(repos);
+        }
+        for (repos) |repo| {
+            const st = getRepoStatus(allocator, repo) catch |e| {
+                std.debug.print("failed to fetch status for {s}: {s}\n", .{ repo, @errorName(e) });
+                continue;
+            };
+            defer allocator.free(st);
+            std.debug.print("{s} {s}\n", .{ status.statusIcon(st), repo });
+        }
+    }
+}

--- a/status.zig
+++ b/status.zig
@@ -1,0 +1,53 @@
+const std = @import("std");
+
+pub const StatusMap = struct {
+    match: []const u8,
+    icon: []const u8,
+    color: u8,
+};
+
+pub const status_map = [_]StatusMap{
+    .{ .match = "success", .icon = "✅", .color = 1 },
+    .{ .match = "failure", .icon = "❌", .color = 2 },
+    .{ .match = "timed_out", .icon = "⌛", .color = 2 },
+    .{ .match = "cancelled", .icon = "🛑", .color = 4 },
+    .{ .match = "skipped", .icon = "⏭️", .color = 5 },
+    .{ .match = "in_progress", .icon = "🔁", .color = 7 },
+    .{ .match = "action_required", .icon = "⛔", .color = 6 },
+    .{ .match = "neutral", .icon = "⭕", .color = 3 },
+    .{ .match = "stale", .icon = "🥖", .color = 4 },
+    .{ .match = "queued", .icon = "📋", .color = 3 },
+    .{ .match = "loading", .icon = "🌀", .color = 3 },
+    // default
+    .{ .match = "", .icon = "➖", .color = 3 },
+};
+
+pub fn statusIcon(status: []const u8) []const u8 {
+    for (status_map) |m| {
+        if (m.match.len == 0) break; // default handled later
+        if (std.mem.indexOf(u8, status, m.match) != null) return m.icon;
+    }
+    return status_map[status_map.len - 1].icon;
+}
+
+pub fn statusColor(status: []const u8) u8 {
+    for (status_map) |m| {
+        if (m.match.len == 0) break;
+        if (std.mem.indexOf(u8, status, m.match) != null) return m.color;
+    }
+    return status_map[status_map.len - 1].color;
+}
+
+const testing = std.testing;
+
+test "status icon mapping" {
+    try testing.expectEqualStrings("✅", statusIcon("success"));
+    try testing.expectEqualStrings("❌", statusIcon("failure"));
+    try testing.expectEqualStrings("➖", statusIcon("unknown"));
+}
+
+test "status color mapping" {
+    try testing.expectEqual(@as(u8, 1), statusColor("success"));
+    try testing.expectEqual(@as(u8, 2), statusColor("failure"));
+    try testing.expectEqual(@as(u8, 3), statusColor("unknown"));
+}


### PR DESCRIPTION
## Summary
- Document new Zig port of the GitHub Actions build monitor.
- Introduce `status.zig` with status-to-emoji/color mapping and unit tests.
- Add `ghstatus.zig` CLI using the GitHub CLI to list repos and display workflow status icons.

## Testing
- `zig test status.zig`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68a73d845be88328bc7fffcf30b7a148