### PR TITLE
Implement status helpers in NASM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,17 @@ LDFLAGS ?= -lncursesw
 
 all: ghstatus
 
-ghstatus: ghstatus.c
-	$(CC) $(CFLAGS) -o $@ $< $(LDFLAGS)
+ghstatus: ghstatus.c status.o
+	$(CC) $(CFLAGS) -o $@ ghstatus.c status.o $(LDFLAGS)
+
+status.o: status.asm
+	nasm -f elf64 $< -o $@
 
 test: test_status
 	./test_status
 
-test_status: test_status.c ghstatus.c
-	$(CC) $(CFLAGS) -o $@ test_status.c $(LDFLAGS)
+test_status: test_status.c status.o
+	$(CC) $(CFLAGS) -o $@ test_status.c status.o $(LDFLAGS)
 
 clean:
-	rm -f ghstatus test_status
+	rm -f ghstatus test_status status.o

--- a/ghstatus.c
+++ b/ghstatus.c
@@ -56,6 +56,9 @@ pid_t fetch_pids[MAX_REPOS];
 // button hover state
 int hover_x = -1, hover_y = -1;
 
+const wchar_t *status_icon(const char *status);
+int status_color(const char *status);
+
 void load_repos(const char *user) {
   int fds[2];
   if (pipe(fds) == -1)
@@ -126,21 +129,6 @@ void load_repos(const char *user) {
   }
 }
 
-const wchar_t *status_icon(const char *status) {
-  for (size_t i = 0; i < STATUS_KNOWN; i++) {
-    if (strstr(status, status_map[i].match))
-      return status_map[i].icon;
-  }
-  return status_map[STATUS_KNOWN].icon;
-}
-
-int status_color(const char *status) {
-  for (size_t i = 0; i < STATUS_KNOWN; i++) {
-    if (strstr(status, status_map[i].match))
-      return status_map[i].color;
-  }
-  return status_map[STATUS_KNOWN].color;
-}
 
 void spawn_fetches(int pipes[][2], pid_t pids[], int max_concurrent_fetches) {
   // tear down any previous fetches

--- a/status.asm
+++ b/status.asm
@@ -1,0 +1,83 @@
+%define STATUS_KNOWN 11
+%define ENTRY_SIZE 24
+%define OFFSET_MATCH 0
+%define OFFSET_ICON 8
+%define OFFSET_COLOR 16
+
+extern status_map
+extern strstr
+
+default rel
+
+global status_icon
+section .text
+status_icon:
+    push rbp
+    mov rbp, rsp
+    push rbx
+    push r12
+    lea rbx, [status_map]
+    mov r12, rdi
+    xor ecx, ecx
+.loop:
+    cmp ecx, STATUS_KNOWN
+    jge .default
+    mov rsi, [rbx + OFFSET_MATCH]
+    mov rdi, r12
+    push rcx
+    push rbx
+    call strstr wrt ..plt
+    pop rbx
+    pop rcx
+    test rax, rax
+    jnz .found
+    add rbx, ENTRY_SIZE
+    inc ecx
+    jmp .loop
+.found:
+    mov rax, [rbx + OFFSET_ICON]
+    jmp .done
+.default:
+    mov rax, [rbx + OFFSET_ICON]
+.done:
+    pop r12
+    pop rbx
+    pop rbp
+    ret
+
+global status_color
+status_color:
+    push rbp
+    mov rbp, rsp
+    push rbx
+    push r12
+    lea rbx, [status_map]
+    mov r12, rdi
+    xor ecx, ecx
+.loop2:
+    cmp ecx, STATUS_KNOWN
+    jge .default2
+    mov rsi, [rbx + OFFSET_MATCH]
+    mov rdi, r12
+    push rcx
+    push rbx
+    call strstr wrt ..plt
+    pop rbx
+    pop rcx
+    test rax, rax
+    jnz .found2
+    add rbx, ENTRY_SIZE
+    inc ecx
+    jmp .loop2
+.found2:
+    mov eax, dword [rbx + OFFSET_COLOR]
+    jmp .done2
+.default2:
+    mov eax, dword [rbx + OFFSET_COLOR]
+.done2:
+    pop r12
+    pop rbx
+    pop rbp
+    ret
+
+section .note.GNU-stack noalloc noexec nowrite progbits


### PR DESCRIPTION
## Summary
- Reimplement status_icon and status_color in NASM x86_64
- Update build to assemble and link the new NASM helpers

## Testing
- `make test`
- `make ghstatus`

------
https://chatgpt.com/codex/tasks/task_e_68a73db73efc832881475e7568a3194c