### PR TITLE
Add Haskell build monitor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ all: ghstatus
 ghstatus: ghstatus.c
 	$(CC) $(CFLAGS) -o $@ $< $(LDFLAGS)
 
+ghstatus-hs: ghstatus.hs
+	ghc -O2 -o $@ $<
+
 test: test_status
 	./test_status
 
@@ -16,4 +19,4 @@ test_status: test_status.c ghstatus.c
 	$(CC) $(CFLAGS) -o $@ test_status.c $(LDFLAGS)
 
 clean:
-	rm -f ghstatus test_status
+	rm -f ghstatus test_status ghstatus-hs

--- a/README.md
+++ b/README.md
@@ -49,3 +49,24 @@ The tool relies on the GitHub CLI for API requests. To access private
 repositories the CLI must be authenticated (`gh auth login`) and the account
 must have permission to view those repositories. Without authentication or
 appropriate access, private repository information cannot be displayed.
+
+## Haskell version
+
+The `ghstatus.hs` program offers a lightweight console monitor written in Haskell. It relies on the GitHub CLI to retrieve workflow information and prints an emoji icon for the latest run status of each repository.
+
+### Dependencies
+
+- `ghc`
+- [GitHub CLI](https://cli.github.com/)
+
+### Build
+
+```sh
+ghc -O2 -o ghstatus-hs ghstatus.hs
+```
+
+### Usage
+
+```sh
+./ghstatus-hs <user> [user2 ...]
+```

--- a/ghstatus.hs
+++ b/ghstatus.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+import System.Environment (getArgs)
+import System.Process (readProcess)
+import Control.Monad (mapM_)
+import Data.Char (isSpace)
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+
+statusMap :: Map String String
+statusMap = Map.fromList
+  [ ("success", "✅")
+  , ("failure", "❌")
+  , ("timed_out", "⌛")
+  , ("cancelled", "🛑")
+  , ("skipped", "⏭️")
+  , ("in_progress", "🔁")
+  , ("action_required", "⛔")
+  , ("neutral", "⭕")
+  , ("stale", "🥖")
+  , ("queued", "📋")
+  , ("loading", "🌀")
+  ]
+
+strip :: String -> String
+strip = reverse . dropWhile isSpace . reverse . dropWhile isSpace
+
+jqExpr :: String
+jqExpr = ".workflow_runs[0].conclusion // .workflow_runs[0].status // \"loading\""
+
+main :: IO ()
+main = do
+  users <- getArgs
+  if null users
+     then putStrLn "usage: ghstatus-hs <user> [user2 ...]"
+     else do
+       repos <- concat <$> mapM fetchRepos users
+       mapM_ printStatus repos
+
+fetchRepos :: String -> IO [String]
+fetchRepos u = do
+  out <- readProcess "gh" ["repo","list",u,"--public","--limit","500","--json","nameWithOwner","--jq",".[].nameWithOwner"] ""
+  pure (lines out)
+
+fetchStatus :: String -> IO String
+fetchStatus repo = do
+  out <- readProcess "gh" ["api","repos/" ++ repo ++ "/actions/runs?per_page=1","--jq",jqExpr] ""
+  pure (strip out)
+
+printStatus :: String -> IO ()
+printStatus repo = do
+  st <- fetchStatus repo
+  putStrLn (iconFor st ++ " " ++ repo)
+
+iconFor :: String -> String
+iconFor st = fromMaybe "➖" (Map.lookup st statusMap)


### PR DESCRIPTION
## Summary
- add a simple Haskell implementation that queries GitHub via the CLI and prints workflow status icons
- document Haskell version and build steps in README
- support building the Haskell program via `make ghstatus-hs`

## Testing
- `ghc -O2 -o ghstatus-hs ghstatus.hs`
- `make test`
- `./ghstatus-hs`


------
https://chatgpt.com/codex/tasks/task_e_68a73dc3fbcc8328890033afe137578f