### PR TITLE
Validate CLI options for positive minimums

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ user's repositories. Optional flags allow customization of refresh timing and
 concurrency:
 
 ```sh
-./ghstatus [-p seconds] [-c count] <user> [user2 ...]
+./ghstatus [-p seconds>=1] [-c count>=1] <user> [user2 ...]
 ```
 
-`-p` sets the refresh interval in seconds (default 300) and `-c` limits the
-number of simultaneous fetches (default 32).
+`-p` sets the refresh interval in seconds (default 300, minimum 1) and `-c`
+limits the number of simultaneous fetches (default 32, minimum 1).
 
 The tool relies on the GitHub CLI for API requests. To access private
 repositories the CLI must be authenticated (`gh auth login`) and the account

--- a/test_status.c
+++ b/test_status.c
@@ -14,5 +14,8 @@ int main(void) {
   assert(status_color("success") == 1);
   assert(status_color("failure") == 2);
   assert(status_color("unknown") == 3);
+
+  assert(sanitize_positive_option("test", 5, 10, 0) == 5);
+  assert(sanitize_positive_option("test", 0, 10, 0) == 10);
   return 0;
 }


### PR DESCRIPTION
## Summary
- ensure the poll interval and max concurrent fetch count fallback to defaults when less than one
- update CLI usage text and README to document the valid ranges
- cover the new validation helper with unit tests

## Testing
- make
- make test

------
https://chatgpt.com/codex/tasks/task_e_68ddceaddc5083288f60d217a16f3fea