### PR TITLE
Ignore active runs when averaging workflow durations

### DIFF
--- a/ghstatus.js
+++ b/ghstatus.js
@@ -44,8 +44,11 @@ function escapeHtml(value) {
     .replace(/'/g, "&#39;");
 }
 
-let CONCURRENCY_LIMIT = window.CONCURRENCY_LIMIT || 5;
-window.CONCURRENCY_LIMIT = CONCURRENCY_LIMIT;
+let CONCURRENCY_LIMIT = 5;
+if (typeof window !== "undefined") {
+  CONCURRENCY_LIMIT = window.CONCURRENCY_LIMIT || CONCURRENCY_LIMIT;
+  window.CONCURRENCY_LIMIT = CONCURRENCY_LIMIT;
+}
 
 function limitConcurrency(limit) {
   let active = 0;
@@ -493,6 +496,13 @@ function accumulateSummary(runs) {
     if (key === "in_progress" || key === "queued") {
       summaryState.inProgress += 1;
     }
+
+    const status = (run.status || "").toLowerCase();
+    const hasConclusion = run.conclusion != null;
+    if (status !== "completed" && !hasConclusion) {
+      return;
+    }
+
     const started = run.created_at ? new Date(run.created_at) : null;
     const completed = run.updated_at ? new Date(run.updated_at) : null;
     if (started && completed && completed >= started) {
@@ -667,17 +677,27 @@ async function load(event) {
   form.classList.remove("loading");
 }
 
-document.getElementById("user-form").addEventListener("submit", load);
-document.getElementById("load").addEventListener("click", load);
+if (typeof document !== "undefined") {
+  document.getElementById("user-form").addEventListener("submit", load);
+  document.getElementById("load").addEventListener("click", load);
 
-document.getElementById("users").addEventListener("keydown", (event) => {
-  if (event.key === "Enter" && !event.shiftKey) {
-    event.preventDefault();
-    load(event);
-  }
-});
+  document.getElementById("users").addEventListener("keydown", (event) => {
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      load(event);
+    }
+  });
 
-// Auto-load the default example when the page is first opened.
-window.addEventListener("DOMContentLoaded", () => {
-  load();
-});
+  // Auto-load the default example when the page is first opened.
+  window.addEventListener("DOMContentLoaded", () => {
+    load();
+  });
+}
+
+if (typeof module !== "undefined") {
+  module.exports = {
+    accumulateSummary,
+    resetSummary,
+    summaryState,
+  };
+}

--- a/ghstatus.test.js
+++ b/ghstatus.test.js
@@ -1,0 +1,44 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { accumulateSummary, resetSummary, summaryState } = require("./ghstatus.js");
+
+test("accumulateSummary ignores active runs when averaging durations", () => {
+  resetSummary();
+
+  const baseTime = Date.UTC(2024, 0, 1, 0, 0, 0);
+  const runs = [
+    {
+      status: "in_progress",
+      conclusion: null,
+      created_at: new Date(baseTime - 4_000).toISOString(),
+      updated_at: new Date(baseTime).toISOString(),
+    },
+    {
+      status: "completed",
+      conclusion: "success",
+      created_at: new Date(baseTime - 12_000).toISOString(),
+      updated_at: new Date(baseTime - 7_000).toISOString(),
+    },
+    {
+      status: "queued",
+      conclusion: null,
+      created_at: new Date(baseTime - 20_000).toISOString(),
+      updated_at: new Date(baseTime - 15_000).toISOString(),
+    },
+    {
+      status: "completed",
+      conclusion: null,
+      created_at: new Date(baseTime - 40_000).toISOString(),
+      updated_at: new Date(baseTime - 30_000).toISOString(),
+    },
+  ];
+
+  accumulateSummary(runs);
+
+  assert.equal(summaryState.repos, 1);
+  assert.equal(summaryState.totalRuns, runs.length);
+  assert.equal(summaryState.inProgress, 2);
+  assert.equal(summaryState.durationSamples, 2);
+  assert.equal(summaryState.durations, 15_000);
+});


### PR DESCRIPTION
## Summary
- avoid accumulating workflow durations unless the run has completed or produced a conclusion
- guard browser-specific globals and export summary helpers for tests
- add a node-based test confirming active runs are excluded from average duration calculations

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_69020dca13a08328b49467b63fa8659d